### PR TITLE
[CONTEST] 콘테스트 게시글 목록 조회 필터링 기능 구현

### DIFF
--- a/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
+++ b/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.List;
  * 수정일        수정자        수정내용
  * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
- * 2024.09.01   정은찬        콘테스트 게시글 목록 조회 최신순, 추천순 메소드 추가
+ * 2024.09.01   정은찬        파라미터를 통해 콘테스트 게시글 목록 조회 통합
  * </pre>
  */
 @RestController
@@ -33,46 +34,16 @@ public class ContestController {
     private final ContestService service;
 
     /**
-     * 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬)
+     * 콘테스트 게시글 목록 조회
      *
      * @author 정은찬
-     * @apiNote 진행중인 콘테스트 게시글 목록을 최신순으로 조회한다.
+     * @apiNote 콘테스트 게시글 목록을 파라미터를 통해 진행중, 완료, 최신순, 추천순을 조회한다.
      */
-    @GetMapping("/ongoing/latest")
-    public ResponseEntity<List<PostSummaryDTO>> getOngoingContestPostListOrderByLatest() {
-        return ResponseEntity.ok(service.getOngoingContestPostListOrderByLatest());
-    }
+    @GetMapping("/posts")
+    public ResponseEntity<List<PostSummaryDTO>> getContestPostList(
+            @RequestParam("status") String contestStatus,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "latest") String sortBy) {
 
-    /**
-     * 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬)
-     *
-     * @author 정은찬
-     * @apiNote 진행중인 콘테스트 게시글 목록을 추천순으로 조회한다.
-     */
-    @GetMapping("/ongoing/recommend")
-    public ResponseEntity<List<PostSummaryDTO>> getOngoingContestPostListOrderByRecommend() {
-        return ResponseEntity.ok(service.getOngoingContestPostListOrderByRecommend());
-    }
-
-    /**
-     * 완료된 콘테스트 게시글 목록 조회 (최신순 정렬)
-     *
-     * @author 정은찬
-     * @apiNote 완료된 콘테스트 게시글 목록을 최신순으로 조회한다.
-     */
-    @GetMapping("/finished/latest")
-    public ResponseEntity<List<PostSummaryDTO>> getFinishedContestPostListOrderByLatest() {
-        return ResponseEntity.ok(service.getFinishedContestPostListOrderByLatest());
-    }
-
-    /**
-     * 완료된 콘테스트 게시글 목록 조회 (추천순 정렬)
-     *
-     * @author 정은찬
-     * @apiNote 완료된 콘테스트 게시글 목록을 추천순으로 조회한다.
-     */
-    @GetMapping("/finished/recommend")
-    public ResponseEntity<List<PostSummaryDTO>> getFinishedContestPostListOrderByRecommend() {
-        return ResponseEntity.ok(service.getFinishedContestPostListOrderByRecommend());
+        return ResponseEntity.ok(service.getContestPostList(contestStatus, sortBy));
     }
 }

--- a/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
+++ b/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
@@ -32,14 +32,14 @@ public class ContestController {
     private final ContestService service;
 
     /**
-     * 진행중인 콘테스트 게시글 목록 조회
+     * 진행중인 콘테스트 게시글 목록 조회 (최신순)
      *
      * @author 정은찬
      * @apiNote 진행중인 콘테스트 게시글 목록을 조회한다.
      */
-    @GetMapping("/ongoing")
-    public ResponseEntity<List<PostSummaryDTO>> getOngoingContestPostList() {
-        return ResponseEntity.ok(service.getOngoingContestPostList());
+    @GetMapping("/ongoing/latest")
+    public ResponseEntity<List<PostSummaryDTO>> getOngoingContestPostListOrderByLatest() {
+        return ResponseEntity.ok(service.getOngoingContestPostListOrderByLatest());
     }
 
     /**
@@ -48,8 +48,8 @@ public class ContestController {
      * @author 정은찬
      * @apiNote 완료된 콘테스트 게시글 목록을 조회한다.
      */
-    @GetMapping("/finished")
-    public ResponseEntity<List<PostSummaryDTO>> getFinishedContestPostList() {
-        return ResponseEntity.ok(service.getFinishedContestPostList());
+    @GetMapping("/finished/latest")
+    public ResponseEntity<List<PostSummaryDTO>> getFinishedContestPostListOrderByLatest() {
+        return ResponseEntity.ok(service.getFinishedContestPostListOrderByLatest());
     }
 }

--- a/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
+++ b/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
@@ -33,6 +33,7 @@ import java.util.List;
 public class ContestController {
     private final ContestService service;
 
+
     /**
      * 콘테스트 게시글 목록 조회
      *
@@ -40,9 +41,7 @@ public class ContestController {
      * @apiNote 콘테스트 게시글 목록을 파라미터를 통해 진행중, 완료, 최신순, 추천순을 조회한다.
      */
     @GetMapping("/posts")
-    public ResponseEntity<List<PostSummaryDTO>> getContestPostList(
-            @RequestParam("status") String contestStatus,
-            @RequestParam(value = "sortBy", required = false, defaultValue = "latest") String sortBy) {
+    public ResponseEntity<List<PostSummaryDTO>> getContestPostList(@RequestParam("status") String contestStatus, @RequestParam(value = "sortBy", required = false, defaultValue = "latest") String sortBy) {
 
         return ResponseEntity.ok(service.getContestPostList(contestStatus, sortBy));
     }

--- a/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
+++ b/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
@@ -19,9 +19,10 @@ import java.util.List;
  * @version 1.0
  *
  * <pre>
- * 수정일        	수정자        수정내용
- * ----------  --------    ---------------------------
+ * 수정일        수정자        수정내용
+ * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
+ * 2024.09.01   정은찬        콘테스트 게시글 목록 조회 최신순, 추천순 메소드 추가
  * </pre>
  */
 @RestController
@@ -32,10 +33,10 @@ public class ContestController {
     private final ContestService service;
 
     /**
-     * 진행중인 콘테스트 게시글 목록 조회 (최신순)
+     * 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬)
      *
      * @author 정은찬
-     * @apiNote 진행중인 콘테스트 게시글 목록을 조회한다.
+     * @apiNote 진행중인 콘테스트 게시글 목록을 최신순으로 조회한다.
      */
     @GetMapping("/ongoing/latest")
     public ResponseEntity<List<PostSummaryDTO>> getOngoingContestPostListOrderByLatest() {
@@ -43,13 +44,35 @@ public class ContestController {
     }
 
     /**
-     * 완료된 콘테스트 게시글 목록 조회
+     * 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬)
      *
      * @author 정은찬
-     * @apiNote 완료된 콘테스트 게시글 목록을 조회한다.
+     * @apiNote 진행중인 콘테스트 게시글 목록을 추천순으로 조회한다.
+     */
+    @GetMapping("/ongoing/recommend")
+    public ResponseEntity<List<PostSummaryDTO>> getOngoingContestPostListOrderByRecommend() {
+        return ResponseEntity.ok(service.getOngoingContestPostListOrderByRecommend());
+    }
+
+    /**
+     * 완료된 콘테스트 게시글 목록 조회 (최신순 정렬)
+     *
+     * @author 정은찬
+     * @apiNote 완료된 콘테스트 게시글 목록을 최신순으로 조회한다.
      */
     @GetMapping("/finished/latest")
     public ResponseEntity<List<PostSummaryDTO>> getFinishedContestPostListOrderByLatest() {
         return ResponseEntity.ok(service.getFinishedContestPostListOrderByLatest());
+    }
+
+    /**
+     * 완료된 콘테스트 게시글 목록 조회 (추천순 정렬)
+     *
+     * @author 정은찬
+     * @apiNote 완료된 콘테스트 게시글 목록을 추천순으로 조회한다.
+     */
+    @GetMapping("/finished/recommend")
+    public ResponseEntity<List<PostSummaryDTO>> getFinishedContestPostListOrderByRecommend() {
+        return ResponseEntity.ok(service.getFinishedContestPostListOrderByRecommend());
     }
 }

--- a/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
+++ b/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
@@ -10,14 +10,19 @@ import java.util.List;
  * @version 1.0
  *
  * <pre>
- * 수정일        	수정자        수정내용
- * ----------  --------    ---------------------------
+ * 수정일        수정자        수정내용
+ * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
+ * 2024.09.01   정은찬        콘테스트 게시글 목록 최신순, 추천순 조회 추가
  * </pre>
  */
 public interface ContestMapper {
     // 해당 날짜에 진행중인 콘테스트 게시글 목록 조회 (최신순)
     public List<PostSummaryDTO> selectOngoingContestPostListOrderByLatest(String date);
+    // 해당 날짜에 진행중인 콘테스트 게시글 목록 조회 (추천순)
+    public List<PostSummaryDTO> selectOngoingContestPostListOrderByRecommend(String date);
     // 완료된 콘테스트 게시글 목록 조회 (최신순)
     public List<PostSummaryDTO> selectFinishedContestPostListOrderByLatest(String date);
+    // 완료된 콘테스트 게시글 목록 조회 (추천순)
+    public List<PostSummaryDTO> selectFinishedContestPostListOrderByRecommend(String date);
 }

--- a/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
+++ b/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
@@ -16,8 +16,8 @@ import java.util.List;
  * </pre>
  */
 public interface ContestMapper {
-    // 해당 날짜에 진행중인 콘테스트 게시글 목록 조회
-    public List<PostSummaryDTO> selectOngoingContestPostList(String date);
-    // 완료된 콘테스트 게시글 목록 조회
-    public List<PostSummaryDTO> selectFinishedContestPostList(String date);
+    // 해당 날짜에 진행중인 콘테스트 게시글 목록 조회 (최신순)
+    public List<PostSummaryDTO> selectOngoingContestPostListOrderByLatest(String date);
+    // 완료된 콘테스트 게시글 목록 조회 (최신순)
+    public List<PostSummaryDTO> selectFinishedContestPostListOrderByLatest(String date);
 }

--- a/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
+++ b/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
@@ -19,7 +19,6 @@ import java.util.List;
  * </pre>
  */
 public interface ContestMapper {
-    public List<PostSummaryDTO> selectContestPostList(@Param("date") String date,
-                                                      @Param("sortBy") String sortBy,
-                                                      @Param("contestStatus") String contestStatus);
+    // 콘테스트 게시글 목록 조회
+    public List<PostSummaryDTO> selectContestPostList(@Param("date") String date, @Param("sortBy") String sortBy, @Param("contestStatus") String contestStatus);
 }

--- a/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
+++ b/src/main/java/com/oasis/hworld/contest/mapper/ContestMapper.java
@@ -1,6 +1,8 @@
 package com.oasis.hworld.contest.mapper;
 
 import com.oasis.hworld.contest.dto.PostSummaryDTO;
+import org.apache.ibatis.annotations.Param;
+
 import java.util.List;
 
 /**
@@ -13,16 +15,11 @@ import java.util.List;
  * 수정일        수정자        수정내용
  * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
- * 2024.09.01   정은찬        콘테스트 게시글 목록 최신순, 추천순 조회 추가
+ * 2024.09.01   정은찬        쿼리 파라미터를 통해 콘테스트 게시글 조회 통합
  * </pre>
  */
 public interface ContestMapper {
-    // 해당 날짜에 진행중인 콘테스트 게시글 목록 조회 (최신순)
-    public List<PostSummaryDTO> selectOngoingContestPostListOrderByLatest(String date);
-    // 해당 날짜에 진행중인 콘테스트 게시글 목록 조회 (추천순)
-    public List<PostSummaryDTO> selectOngoingContestPostListOrderByRecommend(String date);
-    // 완료된 콘테스트 게시글 목록 조회 (최신순)
-    public List<PostSummaryDTO> selectFinishedContestPostListOrderByLatest(String date);
-    // 완료된 콘테스트 게시글 목록 조회 (추천순)
-    public List<PostSummaryDTO> selectFinishedContestPostListOrderByRecommend(String date);
+    public List<PostSummaryDTO> selectContestPostList(@Param("date") String date,
+                                                      @Param("sortBy") String sortBy,
+                                                      @Param("contestStatus") String contestStatus);
 }

--- a/src/main/java/com/oasis/hworld/contest/service/ContestService.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestService.java
@@ -22,12 +22,12 @@ public interface ContestService {
      *
      * @author 정은찬
      */
-    List<PostSummaryDTO> getOngoingContestPostList();
+    List<PostSummaryDTO> getOngoingContestPostListOrderByLatest();
 
     /**
      * 완료된 콘테스트 게시글 목록 조회
      *
      * @author 정은찬
      */
-    List<PostSummaryDTO> getFinishedContestPostList();
+    List<PostSummaryDTO> getFinishedContestPostListOrderByLatest();
 }

--- a/src/main/java/com/oasis/hworld/contest/service/ContestService.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestService.java
@@ -11,23 +11,38 @@ import java.util.List;
  * @version 1.0
  *
  * <pre>
- * 수정일        	수정자        수정내용
- * ----------  --------    ---------------------------
+ * 수정일        수정자        수정내용
+ * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
+ * 2024.09.01   정은찬        콘테스트 게시글 목록 조회 최신순, 추천순 메소드 추가
  * </pre>
  */
 public interface ContestService {
     /**
-     * 진행중인 콘테스트 게시글 목록 조회
+     * 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬)
      *
      * @author 정은찬
      */
     List<PostSummaryDTO> getOngoingContestPostListOrderByLatest();
 
     /**
-     * 완료된 콘테스트 게시글 목록 조회
+     * 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬)
+     *
+     * @author 정은찬
+     */
+    List<PostSummaryDTO> getOngoingContestPostListOrderByRecommend();
+    
+    /**
+     * 완료된 콘테스트 게시글 목록 조회 (최신순 정렬)
      *
      * @author 정은찬
      */
     List<PostSummaryDTO> getFinishedContestPostListOrderByLatest();
+
+    /**
+     * 완료된 콘테스트 게시글 목록 조회 (추천순 정렬)
+     *
+     * @author 정은찬
+     */
+    List<PostSummaryDTO> getFinishedContestPostListOrderByRecommend();
 }

--- a/src/main/java/com/oasis/hworld/contest/service/ContestService.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestService.java
@@ -14,35 +14,14 @@ import java.util.List;
  * 수정일        수정자        수정내용
  * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
- * 2024.09.01   정은찬        콘테스트 게시글 목록 조회 최신순, 추천순 메소드 추가
+ * 2024.09.01   정은찬        파라미터를 통해 콘테스트 게시글 목록 조회 메소드 통합
  * </pre>
  */
 public interface ContestService {
     /**
-     * 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬)
+     * 진행중인 콘테스트 게시글 목록 조회
      *
      * @author 정은찬
      */
-    List<PostSummaryDTO> getOngoingContestPostListOrderByLatest();
-
-    /**
-     * 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬)
-     *
-     * @author 정은찬
-     */
-    List<PostSummaryDTO> getOngoingContestPostListOrderByRecommend();
-    
-    /**
-     * 완료된 콘테스트 게시글 목록 조회 (최신순 정렬)
-     *
-     * @author 정은찬
-     */
-    List<PostSummaryDTO> getFinishedContestPostListOrderByLatest();
-
-    /**
-     * 완료된 콘테스트 게시글 목록 조회 (추천순 정렬)
-     *
-     * @author 정은찬
-     */
-    List<PostSummaryDTO> getFinishedContestPostListOrderByRecommend();
+    List<PostSummaryDTO> getContestPostList(String contestStatus, String sortBy);
 }

--- a/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
@@ -30,6 +30,7 @@ public class ContestServiceImpl implements ContestService {
 
     private final ContestMapper mapper;
 
+
     /**
      * 콘테스트 게시글 목록 조회
      *

--- a/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
@@ -17,9 +17,10 @@ import java.util.List;
  * @version 1.0
  *
  * <pre>
- * 수정일        	수정자        수정내용
- * ----------  --------    ---------------------------
+ * 수정일        수정자        수정내용
+ * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
+ * 2024.09.01   정은찬        콘테스트 게시글 목록 조회 최신순, 추천순 메소드 추가
  * </pre>
  */
 @Service
@@ -30,7 +31,7 @@ public class ContestServiceImpl implements ContestService {
     private final ContestMapper mapper;
 
     /**
-     * 진행중인 콘테스트 게시글 목록 조회
+     * 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬)
      *
      * @author 정은찬
      */
@@ -46,7 +47,23 @@ public class ContestServiceImpl implements ContestService {
     }
 
     /**
-     * 완료된 콘테스트 게시글 목록 조회
+     * 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬)
+     *
+     * @author 정은찬
+     */
+    public List<PostSummaryDTO> getOngoingContestPostListOrderByRecommend() {
+        Date currentDate = new Date();
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        String formattedDate = dateFormat.format(currentDate);
+
+        List<PostSummaryDTO> postSummaryDTOList = mapper.selectOngoingContestPostListOrderByRecommend(formattedDate);
+
+        return postSummaryDTOList;
+    }
+
+    /**
+     * 완료된 콘테스트 게시글 목록 조회 (최신순 정렬)
      *
      * @author 정은찬
      */
@@ -57,6 +74,22 @@ public class ContestServiceImpl implements ContestService {
         String formattedDate = dateFormat.format(currentDate);
 
         List<PostSummaryDTO> postSummaryDTOList = mapper.selectFinishedContestPostListOrderByLatest(formattedDate);
+
+        return postSummaryDTOList;
+    }
+
+    /**
+     * 완료된 콘테스트 게시글 목록 조회 (추천순 정렬)
+     *
+     * @author 정은찬
+     */
+    public List<PostSummaryDTO> getFinishedContestPostListOrderByRecommend() {
+        Date currentDate = new Date();
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        String formattedDate = dateFormat.format(currentDate);
+
+        List<PostSummaryDTO> postSummaryDTOList = mapper.selectFinishedContestPostListOrderByRecommend(formattedDate);
 
         return postSummaryDTOList;
     }

--- a/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
@@ -20,7 +20,7 @@ import java.util.List;
  * 수정일        수정자        수정내용
  * ----------  --------    ------------------------------------------------------
  * 2024.08.31  	정은찬        최초 생성
- * 2024.09.01   정은찬        콘테스트 게시글 목록 조회 최신순, 추천순 메소드 추가
+ * 2024.09.01   정은찬        파라미터를 통해 콘테스트 게시글 목록 조회 메소드 통합
  * </pre>
  */
 @Service
@@ -31,66 +31,15 @@ public class ContestServiceImpl implements ContestService {
     private final ContestMapper mapper;
 
     /**
-     * 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬)
+     * 콘테스트 게시글 목록 조회
      *
      * @author 정은찬
      */
-    public List<PostSummaryDTO> getOngoingContestPostListOrderByLatest() {
+    public List<PostSummaryDTO> getContestPostList(String contestStatus, String sortBy) {
         Date currentDate = new Date();
-
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String formattedDate = dateFormat.format(currentDate);
 
-        List<PostSummaryDTO> postSummaryDTOList = mapper.selectOngoingContestPostListOrderByLatest(formattedDate);
-
-        return postSummaryDTOList;
-    }
-
-    /**
-     * 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬)
-     *
-     * @author 정은찬
-     */
-    public List<PostSummaryDTO> getOngoingContestPostListOrderByRecommend() {
-        Date currentDate = new Date();
-
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        String formattedDate = dateFormat.format(currentDate);
-
-        List<PostSummaryDTO> postSummaryDTOList = mapper.selectOngoingContestPostListOrderByRecommend(formattedDate);
-
-        return postSummaryDTOList;
-    }
-
-    /**
-     * 완료된 콘테스트 게시글 목록 조회 (최신순 정렬)
-     *
-     * @author 정은찬
-     */
-    public List<PostSummaryDTO> getFinishedContestPostListOrderByLatest() {
-        Date currentDate = new Date();
-
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        String formattedDate = dateFormat.format(currentDate);
-
-        List<PostSummaryDTO> postSummaryDTOList = mapper.selectFinishedContestPostListOrderByLatest(formattedDate);
-
-        return postSummaryDTOList;
-    }
-
-    /**
-     * 완료된 콘테스트 게시글 목록 조회 (추천순 정렬)
-     *
-     * @author 정은찬
-     */
-    public List<PostSummaryDTO> getFinishedContestPostListOrderByRecommend() {
-        Date currentDate = new Date();
-
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        String formattedDate = dateFormat.format(currentDate);
-
-        List<PostSummaryDTO> postSummaryDTOList = mapper.selectFinishedContestPostListOrderByRecommend(formattedDate);
-
-        return postSummaryDTOList;
+        return mapper.selectContestPostList(formattedDate, sortBy, contestStatus);
     }
 }

--- a/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
@@ -34,13 +34,13 @@ public class ContestServiceImpl implements ContestService {
      *
      * @author 정은찬
      */
-    public List<PostSummaryDTO> getOngoingContestPostList() {
+    public List<PostSummaryDTO> getOngoingContestPostListOrderByLatest() {
         Date currentDate = new Date();
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String formattedDate = dateFormat.format(currentDate);
 
-        List<PostSummaryDTO> postSummaryDTOList = mapper.selectOngoingContestPostList(formattedDate);
+        List<PostSummaryDTO> postSummaryDTOList = mapper.selectOngoingContestPostListOrderByLatest(formattedDate);
 
         return postSummaryDTOList;
     }
@@ -50,13 +50,13 @@ public class ContestServiceImpl implements ContestService {
      *
      * @author 정은찬
      */
-    public List<PostSummaryDTO> getFinishedContestPostList() {
+    public List<PostSummaryDTO> getFinishedContestPostListOrderByLatest() {
         Date currentDate = new Date();
 
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
         String formattedDate = dateFormat.format(currentDate);
 
-        List<PostSummaryDTO> postSummaryDTOList = mapper.selectFinishedContestPostList(formattedDate);
+        List<PostSummaryDTO> postSummaryDTOList = mapper.selectFinishedContestPostListOrderByLatest(formattedDate);
 
         return postSummaryDTOList;
     }

--- a/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
+++ b/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
@@ -16,11 +16,10 @@
 -->
 <mapper namespace="com.oasis.hworld.contest.mapper.ContestMapper">
     <!-- 진행중인 콘테스트 게시글 목록 조회 -->
-    <select id="selectOngoingContestPostList">
+    <select id="selectOngoingContestPostListOrderByLatest">
         SELECT
             P.post_id,
             CO.image_url,
-            M.nickname,
             P.like_count,
             COUNT(R.reply_id) AS reply_count
         FROM
@@ -46,12 +45,13 @@
         GROUP BY
             P.post_id,
             CO.image_url,
-            M.nickname,
             P.like_count
+        ORDER BY
+            MAX(P.created_at) DESC
     </select>
 
     <!-- 완료된 콘테스트 게시글 목록 조회 -->
-    <select id="selectFinishedContestPostList">
+    <select id="selectFinishedContestPostListOrderByLatest">
         SELECT
             P.post_id,
             CO.image_url,
@@ -77,5 +77,7 @@
             P.post_id,
             CO.image_url,
             P.like_count
+        ORDER BY
+            MAX(P.created_at) DESC
     </select>
 </mapper>

--- a/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
+++ b/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
@@ -10,12 +10,13 @@
 *
 * <pre>
 * 수정일        	수정자        수정내용
-* ==========  =========    =========
+* ==========  =========    ======================================================
 * 2024.08.31  	정은찬        최초 생성
+* 2024.09.01  	정은찬        콘테스트 게시글 목록 최신순, 추천순 정렬 조회 추가
 * </pre>
 -->
 <mapper namespace="com.oasis.hworld.contest.mapper.ContestMapper">
-    <!-- 진행중인 콘테스트 게시글 목록 조회 -->
+    <!-- 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬) -->
     <select id="selectOngoingContestPostListOrderByLatest">
         SELECT
             P.post_id,
@@ -50,7 +51,42 @@
             MAX(P.created_at) DESC
     </select>
 
-    <!-- 완료된 콘테스트 게시글 목록 조회 -->
+    <!-- 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬) -->
+    <select id="selectOngoingContestPostListOrderByRecommend">
+        SELECT
+            P.post_id,
+            CO.image_url,
+            P.like_count,
+            COUNT(R.reply_id) AS reply_count
+        FROM
+            POST P
+                LEFT JOIN
+            CONTEST C
+            ON
+                P.contest_id = C.contest_id
+                LEFT JOIN
+            MEMBER M
+            ON
+                P.member_id = M.member_id
+                LEFT JOIN
+            COORDINATION CO
+            ON
+                P.coordination_id = CO.coordination_id
+                LEFT JOIN
+            REPLY R
+            ON
+                P.post_id = R.post_id
+        WHERE
+            TO_DATE(#{date}, 'YYYY-MM-DD') BETWEEN C.start_date AND C.end_date
+        GROUP BY
+            P.post_id,
+            CO.image_url,
+            P.like_count
+        ORDER BY
+            MAX(P.like_count) DESC
+    </select>
+
+    <!-- 완료된 콘테스트 게시글 목록 조회 (최신순 정렬) -->
     <select id="selectFinishedContestPostListOrderByLatest">
         SELECT
             P.post_id,
@@ -79,5 +115,36 @@
             P.like_count
         ORDER BY
             MAX(P.created_at) DESC
+    </select>
+
+    <!-- 완료된 콘테스트 게시글 목록 조회 (추천순 정렬) -->
+    <select id="selectFinishedContestPostListOrderByRecommend">
+        SELECT
+            P.post_id,
+            CO.image_url,
+            P.like_count,
+            COUNT(R.reply_id) AS reply_count
+        FROM
+            POST P
+                LEFT JOIN
+            CONTEST C
+            ON
+                P.contest_id = C.contest_id
+                LEFT JOIN
+            COORDINATION CO
+            ON
+                P.coordination_id = CO.coordination_id
+                LEFT JOIN
+            REPLY R
+            ON
+                P.post_id = R.post_id
+        WHERE
+            TO_DATE(#{date}, 'YYYY-MM-DD') > C.end_date
+        GROUP BY
+            P.post_id,
+            CO.image_url,
+            P.like_count
+        ORDER BY
+            MAX(P.like_count) DESC
     </select>
 </mapper>

--- a/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
+++ b/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
@@ -12,12 +12,11 @@
 * 수정일        	수정자        수정내용
 * ==========  =========    ======================================================
 * 2024.08.31  	정은찬        최초 생성
-* 2024.09.01  	정은찬        콘테스트 게시글 목록 최신순, 추천순 정렬 조회 추가
+* 2024.09.01  	정은찬        콘테스트 게시글 목록 조회 query parameter 적용
 * </pre>
 -->
 <mapper namespace="com.oasis.hworld.contest.mapper.ContestMapper">
-    <!-- 진행중인 콘테스트 게시글 목록 조회 (최신순 정렬) -->
-    <select id="selectOngoingContestPostListOrderByLatest">
+    <select id="selectContestPostList">
         SELECT
             P.post_id,
             CO.image_url,
@@ -42,109 +41,23 @@
             ON
                 P.post_id = R.post_id
         WHERE
-            TO_DATE(#{date}, 'YYYY-MM-DD') BETWEEN C.start_date AND C.end_date
+            <if test="contestStatus == 'ongoing'">
+                TO_DATE(#{date}, 'YYYY-MM-DD') BETWEEN C.start_date AND C.end_date
+            </if>
+            <if test="contestStatus == 'finished'">
+                C.end_date &lt; TO_DATE(#{date}, 'YYYY-MM-DD')
+            </if>
         GROUP BY
             P.post_id,
             CO.image_url,
             P.like_count
-        ORDER BY
-            MAX(P.created_at) DESC
-    </select>
-
-    <!-- 진행중인 콘테스트 게시글 목록 조회 (추천순 정렬) -->
-    <select id="selectOngoingContestPostListOrderByRecommend">
-        SELECT
-            P.post_id,
-            CO.image_url,
-            P.like_count,
-            COUNT(R.reply_id) AS reply_count
-        FROM
-            POST P
-                LEFT JOIN
-            CONTEST C
-            ON
-                P.contest_id = C.contest_id
-                LEFT JOIN
-            MEMBER M
-            ON
-                P.member_id = M.member_id
-                LEFT JOIN
-            COORDINATION CO
-            ON
-                P.coordination_id = CO.coordination_id
-                LEFT JOIN
-            REPLY R
-            ON
-                P.post_id = R.post_id
-        WHERE
-            TO_DATE(#{date}, 'YYYY-MM-DD') BETWEEN C.start_date AND C.end_date
-        GROUP BY
-            P.post_id,
-            CO.image_url,
-            P.like_count
-        ORDER BY
-            MAX(P.like_count) DESC
-    </select>
-
-    <!-- 완료된 콘테스트 게시글 목록 조회 (최신순 정렬) -->
-    <select id="selectFinishedContestPostListOrderByLatest">
-        SELECT
-            P.post_id,
-            CO.image_url,
-            P.like_count,
-            COUNT(R.reply_id) AS reply_count
-        FROM
-            POST P
-        LEFT JOIN
-            CONTEST C
-            ON
-                P.contest_id = C.contest_id
-        LEFT JOIN
-            COORDINATION CO
-            ON
-                P.coordination_id = CO.coordination_id
-        LEFT JOIN
-            REPLY R
-            ON
-                P.post_id = R.post_id
-        WHERE
-            TO_DATE(#{date}, 'YYYY-MM-DD') > C.end_date
-        GROUP BY
-            P.post_id,
-            CO.image_url,
-            P.like_count
-        ORDER BY
-            MAX(P.created_at) DESC
-    </select>
-
-    <!-- 완료된 콘테스트 게시글 목록 조회 (추천순 정렬) -->
-    <select id="selectFinishedContestPostListOrderByRecommend">
-        SELECT
-            P.post_id,
-            CO.image_url,
-            P.like_count,
-            COUNT(R.reply_id) AS reply_count
-        FROM
-            POST P
-                LEFT JOIN
-            CONTEST C
-            ON
-                P.contest_id = C.contest_id
-                LEFT JOIN
-            COORDINATION CO
-            ON
-                P.coordination_id = CO.coordination_id
-                LEFT JOIN
-            REPLY R
-            ON
-                P.post_id = R.post_id
-        WHERE
-            TO_DATE(#{date}, 'YYYY-MM-DD') > C.end_date
-        GROUP BY
-            P.post_id,
-            CO.image_url,
-            P.like_count
-        ORDER BY
-            MAX(P.like_count) DESC
+        <choose>
+            <when test="sortBy == 'latest'">
+                ORDER BY MAX(P.created_at) DESC
+            </when>
+            <when test="sortBy == 'recommend'">
+                ORDER BY P.like_count DESC
+            </when>
+        </choose>
     </select>
 </mapper>

--- a/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
+++ b/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
@@ -15,6 +15,8 @@
 * 2024.09.01  	정은찬        콘테스트 게시글 목록 조회 query parameter 적용
 * </pre>
 -->
+
+<!-- 콘테스트 게시글 목록 조회 -->
 <mapper namespace="com.oasis.hworld.contest.mapper.ContestMapper">
     <select id="selectContestPostList">
         SELECT


### PR DESCRIPTION
# 💡 PR 요약
콘테스트 게시글 목록 조회 최신순, 추천순 정렬 기능 구현

## ⭐️ 관련 이슈
- closes : #9 

## 📍 작업한 내용
- 콘테스트 게시글 목록 조회 최신순 정렬
- 콘테스트 게시글 목록 조회 추천순 정렬

## 🔎 결과 및 이슈 공유
진행중인 콘테스트 (최신순)
![image](https://github.com/user-attachments/assets/04a70bd8-7c92-408b-8b5a-799f1a21e37f)


진행중인 콘테스트 (추천순)
![image](https://github.com/user-attachments/assets/c65a9b81-bbd8-4645-ba85-34dcdc6cdbb1)


완료된 콘테스트 (최신순)
![image](https://github.com/user-attachments/assets/755773cd-f4a3-4287-8151-fce0df7078a8)


완료된 콘테스트 (추천순)
![image](https://github.com/user-attachments/assets/8baff508-a6c6-43ca-8306-c5e887742f8e)



## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
