### PR TITLE
[MEMBER] MemberId 어노테이션 추가

### DIFF
--- a/src/main/java/com/oasis/hworld/common/annotation/MemberId.java
+++ b/src/main/java/com/oasis/hworld/common/annotation/MemberId.java
@@ -1,0 +1,11 @@
+package com.oasis.hworld.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberId {
+}

--- a/src/main/java/com/oasis/hworld/common/resolver/MemberIdArgumentResolver.java
+++ b/src/main/java/com/oasis/hworld/common/resolver/MemberIdArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.oasis.hworld.common.resolver;
+
+import com.oasis.hworld.common.annotation.MemberId;
+import com.oasis.hworld.member.domain.Member;
+import com.oasis.hworld.member.mapper.MemberMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+@Slf4j
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberMapper memberMapper;
+
+    public MemberIdArgumentResolver(MemberMapper memberMapper) {
+        this.memberMapper = memberMapper;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String loginId = (String) request.getAttribute("loginId");
+        Member member = memberMapper.selectMemberByLoginId(loginId);
+        return member.getMemberId();
+    }
+}

--- a/src/main/java/com/oasis/hworld/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/oasis/hworld/security/jwt/JwtAuthenticationFilter.java
@@ -56,9 +56,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 //        if (requestURI.equals("/members/login") || requestURI.equals("/members/sign-up")) {
 //            log.info("회원가입 및 로그인 페이지");
-//
-//            // 다음 필터로 요청 전달
-//            filterChain.doFilter(request, response);
 //        } else {
 //            JwtTokenDTO jwtTokenDTO = jwtTokenProvider.resolveToken(request);
 //

--- a/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
+++ b/src/main/webapp/WEB-INF/spring/appServlet/servlet-context.xml
@@ -4,6 +4,7 @@
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xmlns:context="http://www.springframework.org/schema/context"
 			 xmlns:aop="http://www.springframework.org/schema/aop"
+			 xmlns:mvc="http://www.springframework.org/schema/mvc"
 			 xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd
@@ -35,6 +36,14 @@
 			</beans:list>
 		</beans:property>
 	</beans:bean>
+
+	<!-- MVC 활성화 -->
+	<mvc:annotation-driven>
+		<mvc:argument-resolvers>
+			<!-- MemberIdArgumentResolver 빈 등록 -->
+			<beans:bean class="com.oasis.hworld.common.resolver.MemberIdArgumentResolver"/>
+		</mvc:argument-resolvers>
+	</mvc:annotation-driven>
 
 	<context:component-scan base-package="com.oasis.hworld" />
 


### PR DESCRIPTION
# 💡 PR 요약
MemberId 어노테이션 설정 적용

## ⭐️ 관련 이슈
- closes : #18 

## 📍 작업한 내용
- MemberId 어노테이션 사용 설정

## 🔎 결과 및 이슈 공유
1. 어노테이션 사용
<img width="638" alt="image" src="https://github.com/user-attachments/assets/98ec0ee0-8f09-44e8-b51f-ff627062c85f">

2. memberId 반환 확인
<img width="558" alt="image" src="https://github.com/user-attachments/assets/365dc0ed-88df-4e5e-86d0-536bf1459701">

** 근데 아직은 못씁니다 AuthenticationFilter 적용 후 사용 가능 **
(Header에서 loginId를 가져와야 하는데 PostMan 요청 번거로워져서 주석처리함)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
