### PR TITLE
[CONTEST] 게시글 상세 페이지 관련 API 수정

### DIFF
--- a/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
+++ b/src/main/java/com/oasis/hworld/contest/controller/ContestController.java
@@ -86,7 +86,7 @@ public class ContestController {
     @PostMapping("/posts")
     ResponseEntity<CommonResponseDTO> addContestPost(@RequestBody PostRequestDTO postRequestDTO) {
         // todo : memberId 로직 추가
-        return service.addContestPost(7, postRequestDTO) ?
+        return service.addContestPost(1, postRequestDTO) ?
                 ResponseEntity.ok(new CommonResponseDTO(true, "콘테스트 게시글이 등록되었습니다.")) :
                 ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new CommonResponseDTO(false, "같은 코디 게시글이 존재합니다."));
     }
@@ -100,7 +100,7 @@ public class ContestController {
     @PostMapping("/reply")
     ResponseEntity<CommonResponseDTO> addReply(@RequestBody ReplyRequestDTO replyRequestDTO) {
         // todo : memberId 로직 추가
-        return service.addReply(1, replyRequestDTO) ?
+        return service.addReply(17, replyRequestDTO) ?
                 ResponseEntity.ok(new CommonResponseDTO(true, "댓글이 등록되었습니다.")) :
                 ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new CommonResponseDTO(false, "댓글이 등록되지 않았습니다."));
     }

--- a/src/main/java/com/oasis/hworld/contest/dto/ItemOptionDTO.java
+++ b/src/main/java/com/oasis/hworld/contest/dto/ItemOptionDTO.java
@@ -5,28 +5,21 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * 게시글 코디 착용 아이템 DTO
+ * 상품 옵션 DTO
  * @author 정은찬
- * @since 2024.09.01
+ * @since 2024.09.13
  * @version 1.0
  *
  * <pre>
  * 수정일        수정자        수정내용
  * ----------  --------    ---------------------------
- * 2024.09.01  	정은찬        최초 생성
+ * 2024.09.13  	정은찬        최초 생성
  * </pre>
  */
 @Setter
 @Getter
 @ToString
-public class ItemDTO {
-    private int itemId;
-    private String itemName;
-    private String shopName;
-    private String itemImageUrl;
-    private String shopImageUrl;
-    private int categoryId;
-    private String categoryName;
+public class ItemOptionDTO {
     private int itemOptionId;
     private String itemOption;
 }

--- a/src/main/java/com/oasis/hworld/contest/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/oasis/hworld/contest/dto/PostDetailResponseDTO.java
@@ -41,4 +41,6 @@ public class PostDetailResponseDTO {
     private List<ItemDTO> itemList;
     // 댓글 리스트
     private List<ReplyDTO> replyList;
+
+    private List<ItemOptionDTO> itemOptionList;
 }

--- a/src/main/java/com/oasis/hworld/contest/dto/ReplyDTO.java
+++ b/src/main/java/com/oasis/hworld/contest/dto/ReplyDTO.java
@@ -20,6 +20,10 @@ import lombok.ToString;
 @Getter
 @ToString
 public class ReplyDTO {
+    // 댓글 id
+    private int replyId;
+    // 작성자 id
+    private int memberId;
     // 작성자 닉네임
     private String nickname;
     // 댓글 내용

--- a/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
+++ b/src/main/java/com/oasis/hworld/contest/service/ContestServiceImpl.java
@@ -100,6 +100,7 @@ public class ContestServiceImpl implements ContestService {
             itemDTO.setCategoryName(ItemCategory.getCategoryName(itemDTO.getCategoryId()));
             // s3 버킷 이미지 url 추가
             itemDTO.setItemImageUrl(s3BucketUrl + itemDTO.getItemImageUrl());
+            itemDTO.setShopImageUrl(s3BucketUrl + itemDTO.getShopImageUrl());
         });
         if(postDetail == null) {
             throw new CustomException(POST_NOT_EXIST);

--- a/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
+++ b/src/main/resources/com/oasis/hworld/contest/mapper/ContestMapper.xml
@@ -92,15 +92,26 @@
             <result column="item_id" property="itemId"/>
             <result column="item_name" property="itemName"/>
             <result column="shop_name" property="shopName"/>
+            <result column="shop_image_url" property="shopImageUrl"/>
             <result column="item_image_url" property="itemImageUrl"/>
+            <result column="item_option_id" property="itemOptionId"/>
+            <result column="item_option" property="itemOption"/>
             <result column="category_id" property="categoryId"/>
         </collection>
         <collection property="replyList"
                     ofType="com.oasis.hworld.contest.dto.ReplyDTO"
                     javaType="ArrayList">
+            <result column="reply_id" property="replyId"/>
+            <result column="reply_member_id" property="memberId"/>
             <result column="reply_content" property="content"/>
             <result column="reply_nickname" property="nickname"/>
             <result column="reply_created_at" property="createdAt"/>
+        </collection>
+        <collection property="itemOptionList"
+                    ofType="com.oasis.hworld.contest.dto.ItemOptionDTO"
+                    javaType="ArrayList">
+            <result column="dropdown_item_option_id" property="itemOptionId"/>
+            <result column="dropdown_item_option" property="itemOption"/>
         </collection>
     </resultMap>
 
@@ -116,8 +127,15 @@
             I.item_id,
             I.name AS item_name,
             S.name AS shop_name,
+            S.image_url AS shop_image_url,
             I.image_url AS item_image_url,
             I.category_id,
+            IO.item_option_id AS item_option_id,
+            IO.item_option AS item_option,
+            IO.item_option_Id AS dropdown_item_option_id,
+            IO.item_option AS dropdown_item_option,
+            R.reply_id AS reply_id,
+            RM.member_id AS reply_member_id,
             R.content AS reply_content,
             RM.nickname AS reply_nickname,
             TO_CHAR(R.created_at, 'YYYY-MM-DD') AS reply_created_at

--- a/src/main/resources/com/oasis/hworld/member/mapper/MemberMapper.xml
+++ b/src/main/resources/com/oasis/hworld/member/mapper/MemberMapper.xml
@@ -61,8 +61,8 @@
         <![CDATA[
             SELECT
                 CASE
-                   WHEN type = 1 THEN '사용'
-                   WHEN type = 2 THEN '적립'
+                   WHEN type = 1 THEN '적립'
+                   WHEN type = 2 THEN '사용'
                    END AS type,
                 amount,
                 description,


### PR DESCRIPTION
# 💡 PR 요약
게시글 상세 페이지 관련 API 수정하는 작업

## ⭐️ 관련 이슈
- closes : #82 

## 📍 작업한 내용
- ItemDTO, ItemOptionDTO, ReplyDTO 변수 추가
- 변경된 DTO에 맞게 쿼리문 수정

## 🔎 결과 및 이슈 공유
![image](https://github.com/user-attachments/assets/60630276-3727-443a-812c-8bceabaa381d)


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
